### PR TITLE
setup file to speed up system links

### DIFF
--- a/setup_lxplus.sh
+++ b/setup_lxplus.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+# Configuration files to properly set the dependencies on LXPLUS machines with CentOS 7:
+source /cvmfs/sft.cern.ch/lcg/external/gcc/6.1.0/x86_64-slc6/setup.sh
+source /cvmfs/sft.cern.ch/lcg/releases/LCG_93python3/tbb/2018_U1/x86_64-centos7-gcc62-opt/tbb-env.sh
+source /cvmfs/sft.cern.ch/lcg/releases/LCG_93python3/ROOT/6.12.06/x86_64-centos7-gcc62-opt/bin/thisroot.sh 


### PR DESCRIPTION
Adding auxiliary setup file to fix proper dependencies in LXPLUS machines with CentOS 7.

Suggestion is to replace the warnings to source gcc v6.1 to "source setup_lxplus.sh".