### PR TITLE
updating gcc link in LXPLUS setup

### DIFF
--- a/setup_lxplus.sh
+++ b/setup_lxplus.sh
@@ -1,6 +1,4 @@
 #!/bin/sh
 
 # Configuration files to properly set the dependencies on LXPLUS machines with CentOS 7:
-source /cvmfs/sft.cern.ch/lcg/external/gcc/6.2.0/x86_64-centos7-gcc62-opt/setup.sh
-source /cvmfs/sft.cern.ch/lcg/releases/LCG_93python3/tbb/2018_U1/x86_64-centos7-gcc62-opt/tbb-env.sh
-source /cvmfs/sft.cern.ch/lcg/releases/LCG_93python3/ROOT/6.12.06/x86_64-centos7-gcc62-opt/bin/thisroot.sh 
+source /cvmfs/sft.cern.ch/lcg/contrib/gcc/8/x86_64-centos7-gcc8-opt/setup.sh


### PR DESCRIPTION
Updated path to gcc v8 in order to fix issue with FPMC build:

source /cvmfs/sft.cern.ch/lcg/contrib/gcc/8/x86_64-centos7-gcc8-opt/setup.sh

Successfully works with all interfaces.

```
[100%] [100%] [100%] Building Fortran object CMakeFiles/fpmc-paw.dir/Examples/ntuple.f.o
Building Fortran object CMakeFiles/fpmc-root.dir/Examples/dummy_hwaend.f.o
Building Fortran object CMakeFiles/fpmc-hepmc.dir/Examples/dummy_hwaend.f.o
Linking Fortran executable fpmc-paw
[100%] Built target fpmc-lhe
Linking CXX executable fpmc
[100%] Built target fpmc
[100%] Built target fpmc-paw
Linking CXX executable fpmc-hepmc
[100%] Built target fpmc-hepmc
Linking CXX executable fpmc-root
[100%] Built target fpmc-root
```